### PR TITLE
Use new Ipopt method names.

### DIFF
--- a/src/DICE.jl
+++ b/src/DICE.jl
@@ -46,15 +46,15 @@ export solve, options
 
 # Test if system has HSL MA97 installed, fall back to MUMPS if not.
 function selectLinearSolver(solver_name::ipoptLinearSolver = ma97)
-    prob = Ipopt.createProblem(1,[1.],[1.],1,[1.],[1.],1,1,sum,sum,sum,sum);
-    Ipopt.addOption(prob, "sb", "yes");
-    Ipopt.addOption(prob, "print_level", 0);
+    prob = Ipopt.CreateIpoptProblem(1,[1.],[1.],1,[1.],[1.],1,1,sum,sum,sum,sum,sum);
+    Ipopt.AddIpoptStrOption(prob, "sb", "yes");
+    Ipopt.AddIpoptIntOption(prob, "print_level", 0);
     solver_name_string = string(solver_name);
     # Initially, we must check that coinhsl is installed at all if we want a HSL solver.
     # If not, Ipopt will default to try and find any dynamically linked libhsl. If it
     # cannot find one it will hard panic and we can't capture that failure.
     if occursin("ma", solver_name_string)
-        Ipopt.addOption(prob, "linear_solver", "ma27");
+        Ipopt.AddIpoptStrOption(prob, "linear_solver", "ma27");
         try
             # No HSL was found on the system, we return with fallback.
             return runLinearSolverCheck(prob, solver_name_string)
@@ -66,7 +66,7 @@ function selectLinearSolver(solver_name::ipoptLinearSolver = ma97)
         # Outer try will fail if solver string is not in the list of
         # possible Ipopt solvers.
         # For now that's ma27, ma57, ma77, ma86, ma97, pardiso, wsmp, mumps, custom
-        Ipopt.addOption(prob, "linear_solver", solver_name_string);
+        Ipopt.AddIpoptStrOption(prob, "linear_solver", solver_name_string);
         try
             # Inner try attempts to run the dummy program and will crash because
             # the dummy is malformed.


### PR DESCRIPTION
Fixes runtime errors caused when calling method names deprecated in Ipopt 1.